### PR TITLE
fix(space-gtk): fix permissions on spice-client-glib-usb-acl-helper

### DIFF
--- a/spice-gtk/doinst.sh
+++ b/spice-gtk/doinst.sh
@@ -1,0 +1,1 @@
+setcap CAP_FOWNER=+ep usr/libexec/spice-client-glib-usb-acl-helper

--- a/spice-gtk/spice-gtk.SlackBuild
+++ b/spice-gtk/spice-gtk.SlackBuild
@@ -31,7 +31,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PKGNAM=spice-gtk
 VERSION=0.42
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-cf}
 TMP=${TMP:-/tmp/pkg}
 PKG=$TMP/package-$PKGNAM
@@ -138,6 +138,7 @@ cat $CWD/$PKGNAM.SlackBuild > $PKG/usr/doc/$PKGNAM-$VERSION/$PKGNAM.SlackBuild
 
 mkdir -p $PKG/install
 cat $CWD/slack-desc > $PKG/install/slack-desc
+cat $CWD/doinst.sh > $PKG/install/doinst.sh
 if [ -e $CWD/slack-required ]; then
   cat $CWD/slack-required > $PKG/install/slack-required
 fi


### PR DESCRIPTION
There is some background on this fix here: https://unix.stackexchange.com/questions/694169/how-to-make-a-usb-device-available-to-a-qemu-guest
It suggests using `setuid` on `spice-client-glib-usb-acl-helper`, but I stole the fix from the arch build script from here: https://gitlab.archlinux.org/archlinux/packaging/packages/spice-gtk/-/blob/main/spice-gtk.install?ref_type=heads
It opts for using `setcap` which I guess is more granular.
This fixes `spice-gtk` to allow redirecting usb devices to guest vms as an unprivileged user